### PR TITLE
Remove flake8 nodeset and fix typo

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -1,0 +1,9 @@
+- job:
+    name: flake8
+    description: |
+      Invoke and run flake8
+    run: playbooks/flake8.yml
+    nodeset:
+      nodes:
+        name: container
+        label: f27-oci


### PR DESCRIPTION
The base job default nodeset is already set to the container node.