### PR TITLE
tox-awx: remove custom playbook

### DIFF
--- a/playbooks/tox-with-sudo.yaml
+++ b/playbooks/tox-with-sudo.yaml
@@ -1,3 +1,0 @@
-- hosts: all
-  roles:
-    - tox

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2,7 +2,6 @@
     name: tox-awx
     parent: tox
     pre-run: playbooks/clean-static-node.yaml
-    run: playbooks/tox-with-sudo.yaml
     nodeset: static-node
     abstract: true
 


### PR DESCRIPTION
This change removes the custom playbook and restores
the revoke sudo role.