### PR TITLE
Rename schema job to be more clear about its purpose

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -36,7 +36,7 @@
       tox_envlist: swagger
 
 - job:
-    name: tox-awx-schemavalidation
+    name: tox-awx-detect-schema-change
     parent: tox-awx
     vars:
-      tox_envlist: validate-schema
+      tox_envlist: detect-schema-change

--- a/zuul.d/templates.yaml
+++ b/zuul.d/templates.yaml
@@ -31,7 +31,7 @@
         - tox-awx-api
         - tox-awx-ui
         - tox-awx-swagger
-        - tox-awx-schemavalidation:
+        - tox-awx-detect-schema-change:
             voting: false
     gate:
       queue: awx
@@ -41,5 +41,5 @@
         - tox-awx-api
         - tox-awx-ui
         - tox-awx-swagger
-        - tox-awx-schemavalidation:
+        - tox-awx-detect-schema-change:
             voting: false


### PR DESCRIPTION
The job fails when it detects schema changes, not when schema is invalid.