### PR TITLE
Make ui-next jobs voting

### DIFF
--- a/zuul.d/templates.yaml
+++ b/zuul.d/templates.yaml
@@ -28,12 +28,10 @@
       jobs:
         - awx-api-lint
         - awx-ui-lint
-        - awx-ui-next-lint:
-            voting: false
+        - awx-ui-next-lint
         - awx-api
         - awx-ui
-        - awx-ui-next:
-            voting: false
+        - awx-ui-next
         - awx-swagger
         - awx-detect-schema-change:
             voting: false
@@ -42,12 +40,10 @@
       jobs:
         - awx-api-lint
         - awx-ui-lint
-        - awx-ui-next-lint:
-            voting: false
+        - awx-ui-next-lint
         - awx-api
         - awx-ui
-        - awx-ui-next:
-            voting: false
+        - awx-ui-next
         - awx-swagger
         - awx-detect-schema-change:
             voting: false


### PR DESCRIPTION
Plan was to wait until https://github.com/ansible/awx/pull/4188 merged before flipping these over to be voting.