### PR TITLE
awx: Use tox from within the venv

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2,7 +2,7 @@
     name: awx-api-lint
     parent: awx-tests
     vars:
-      command: tox -e linters
+      command: /venv/awx/bin/tox -e linters
 
 - job:
     name: awx-api


### PR DESCRIPTION
This reverts commit c8ceaaceaecb2bb20fee34292a5c95dd823d3d02.