### PR TITLE
Remove old test jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -17,12 +17,6 @@
       command: make ui-zuul-lint-and-test
 
 - job:
-    name: awx-ui-next
-    parent: awx-tests
-    vars:
-      command: make ui-next-zuul-lint-and-test
-
-- job:
     name: awx-swagger
     parent: awx-tests
     vars:

--- a/zuul.d/templates.yaml
+++ b/zuul.d/templates.yaml
@@ -30,7 +30,6 @@
         - awx-api-lint
         - awx-api
         - awx-ui
-        - awx-ui-next
         - awx-swagger
         - awx-detect-schema-change:
             voting: false
@@ -41,7 +40,6 @@
         - awx-api-lint
         - awx-api
         - awx-ui
-        - awx-ui-next
         - awx-swagger
         - awx-detect-schema-change:
             voting: false


### PR DESCRIPTION
- We've removed the old ui code from devel. 
- There will now only be one zuul job for ui - `awx-ui`. 
- The `make` targets it uses are now running the tests for the new ui, so we can delete the `*-next` job